### PR TITLE
Changing the import statement from using angle brackets to using double quotations

### DIFF
--- a/Pod/Classes/BVAnalytics.h
+++ b/Pod/Classes/BVAnalytics.h
@@ -7,7 +7,7 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#import <BVSettings.h>
+#import "BVSettings.h"
 
 /*!
  BVAnalytics is a singleton object which queues, batches, and handles analytics event requests.


### PR DESCRIPTION
In BVAnalytics.h, the import statement for BVSettings was using angle brackets.  This is causing a build failure under Xcode 7 when brought in as a pod for a hybrid Swift/Objective-C project.  

Seeing as the import is not referencing an external framework, there really isn't a need for the angle brackets and double quotations should suffice.