### PR TITLE
Converting deprecated NSURLConnection to NSURLSession

### DIFF
--- a/Pod/Classes/BVAnalytics.m
+++ b/Pod/Classes/BVAnalytics.m
@@ -78,9 +78,6 @@ static BVAnalytics* BVAnalyticsSingleton = nil;
     // blanket error catching
     //
     @try {
-    
-        NSOperationQueue* networkQueue = [[NSOperationQueue alloc] init];
-       
         // Batch the queued up events, and send the request on a background thread
         //
         if([self.impressionQueue count] > 0) {
@@ -94,8 +91,8 @@ static BVAnalytics* BVAnalyticsSingleton = nil;
             NSURL *url = [[NSURL alloc] initWithString:batchedEventsUrl];
             NSURLRequest* request = [[NSURLRequest alloc] initWithURL:url cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:10];
             
-            
-            [NSURLConnection sendAsynchronousRequest:request queue:networkQueue completionHandler:^(NSURLResponse *response, NSData *data, NSError *connectionError) {
+            NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+            NSURLSessionDataTask *sessionTask = [session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
                 // Used for testing purposes
                 //
                 
@@ -103,6 +100,7 @@ static BVAnalytics* BVAnalyticsSingleton = nil;
                     [[NSNotificationCenter defaultCenter] postNotificationName:@"BV_INTERNAL_IMPRESSION_ANALYTICS_COMPLETED" object:nil];
                 });
             }];
+            [sessionTask resume];
         }
         
         // Fire pageview events
@@ -122,14 +120,15 @@ static BVAnalytics* BVAnalyticsSingleton = nil;
             NSURL *url = [[NSURL alloc] initWithString:formatedEventUrl];
             NSURLRequest* request = [[NSURLRequest alloc] initWithURL:url cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:10];
             
-            
-            [NSURLConnection sendAsynchronousRequest:request queue:networkQueue completionHandler:^(NSURLResponse *response, NSData *data, NSError *connectionError) {
+            NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+            NSURLSessionDataTask *sessionTask = [session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
                 // Used for testing purposes
                 //
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [[NSNotificationCenter defaultCenter] postNotificationName:@"BV_INTERNAL_PAGEVIEW_ANALYTICS_COMPLETED" object:nil];
                 });
             }];
+            [sessionTask resume];
         }
     }
     

--- a/Pod/Classes/BVNetwork.h
+++ b/Pod/Classes/BVNetwork.h
@@ -12,7 +12,7 @@
 #define SDK_HEADER_NAME @"X-UA-BV-SDK"
 #define SDK_HEADER_VALUE @"IOS_SDK_V228"
 
-@interface BVNetwork : NSObject<NSURLConnectionDataDelegate>
+@interface BVNetwork : NSObject<NSURLSessionDataDelegate>
 
 - (id)initWithSender:(id)sender;
 

--- a/Pod/Classes/BVNetwork.m
+++ b/Pod/Classes/BVNetwork.m
@@ -142,11 +142,13 @@ static NSString *urlEncode(id object) {
     
     
     
-    NSURLConnection *theConnection =[[NSURLConnection alloc] initWithRequest:request delegate:self startImmediately:NO];
-    [theConnection scheduleInRunLoop:[NSRunLoop mainRunLoop]
-                             forMode:NSDefaultRunLoopMode];
-    [theConnection start];
-    if (theConnection) {
+    NSURLSession *session = [NSURLSession
+                             sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]
+                             delegate:self
+                             delegateQueue:nil];
+    NSURLSessionDataTask *sessionTask = [session dataTaskWithRequest:request];
+    [sessionTask resume];
+    if (sessionTask) {
         // Create the NSMutableData to hold the received data.
         // receivedData is an instance variable declared elsewhere.
         self.receivedData = [NSMutableData data];
@@ -190,11 +192,13 @@ static NSString *urlEncode(id object) {
     // Attach the SDK version header to every request.
     [request addValue:SDK_HEADER_VALUE forHTTPHeaderField:SDK_HEADER_NAME];
     
-    NSURLConnection *theConnection =[[NSURLConnection alloc] initWithRequest:request delegate:self startImmediately:NO];
-        [theConnection scheduleInRunLoop:[NSRunLoop mainRunLoop]
-                                 forMode:NSDefaultRunLoopMode];
-        [theConnection start];
-    if (theConnection) {
+    NSURLSession *session = [NSURLSession
+                             sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]
+                             delegate:self
+                             delegateQueue:nil];
+    NSURLSessionDataTask *sessionTask = [session dataTaskWithRequest:request];
+    [sessionTask resume];
+    if (sessionTask) {
         // Create the NSMutableData to hold the received data.
         // receivedData is an instance variable declared elsewhere.
         self.receivedData = [NSMutableData data];
@@ -279,56 +283,56 @@ static NSString *urlEncode(id object) {
 
 
 
-#pragma mark NSURLConnection delegates
-- (void)connectionDidFinishLoading:(NSURLConnection *)connection {
-    NSError *error = nil;
-    NSDictionary *response;
-    if ([[self.responseHeaders objectForKey:@"Content-Type"] isEqualToString:@"application/json;charset=utf-8"]) {
-            response = [NSJSONSerialization JSONObjectWithData:self.receivedData options:NSJSONReadingMutableContainers error:&error];
-    }
-    else if (self.responseStatusCode == 200) {
-        NSMutableDictionary *result = [NSMutableDictionary dictionary];
-        [result setObject:self.responseObject.URL forKey:@"URL"];
-        [result setObject:@(self.responseStatusCode) forKey:@"statusCode"];
-        [result setObject:self.responseHeaders forKey:@"headers"];
-        [result setObject:@(NO) forKey:@"HasErrors"];
-        response = result;
-    }
-    if (self.delegate != nil && [self.delegate respondsToSelector:@selector(didReceiveResponse:forRequest:)]) {
-        
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [[BVAnalytics instance] queueAnalyticsEventForResponse:response forRequest:self.sender];
-        });
-        
-        [self.delegate didReceiveResponse:response forRequest:self.sender];
-    }
-}
+#pragma mark NSURLSession delegates
 
-- (void)connection:(NSURLConnection *)connection didSendBodyData:(NSInteger)bytesWritten totalBytesWritten:(NSInteger)totalBytesWritten totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite
-{
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didSendBodyData:(int64_t)bytesSent totalBytesSent:(int64_t)totalBytesSent totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
     if (self.delegate != nil && [self.delegate respondsToSelector:@selector(didSendBodyData:totalBytesWritten:totalBytesExpectedToWrite:forRequest:)])
     {
-        [self.delegate didSendBodyData:bytesWritten totalBytesWritten:totalBytesWritten totalBytesExpectedToWrite:totalBytesExpectedToWrite forRequest:self.sender];
+        [self.delegate didSendBodyData:bytesSent totalBytesWritten:totalBytesSent totalBytesExpectedToWrite:totalBytesExpectedToSend forRequest:self.sender];
     }
 }
 
-
-- (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response {
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSessionResponseDisposition))completionHandler {
     self.responseObject = (NSHTTPURLResponse*) response;
     self.responseHeaders = [self.responseObject allHeaderFields];
     self.responseStatusCode = [self.responseObject statusCode];
     [self.receivedData setLength:0];
+    
+    completionHandler(NSURLSessionResponseAllow);
 }
 
-- (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data {
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data {
     [self.receivedData appendData:data];
 }
 
-- (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error {
-    if (self.delegate != nil && [self.delegate respondsToSelector:@selector(didFailToReceiveResponse:forRequest:)]){
-        [self.delegate didFailToReceiveResponse:error forRequest:self.sender];
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error {
+    if (error != nil) {
+        if (self.delegate != nil && [self.delegate respondsToSelector:@selector(didFailToReceiveResponse:forRequest:)]){
+            [self.delegate didFailToReceiveResponse:error forRequest:self.sender];
+        }
+    } else {
+        NSError *error = nil;
+        NSDictionary *response;
+        if ([[self.responseHeaders objectForKey:@"Content-Type"] isEqualToString:@"application/json;charset=utf-8"]) {
+            response = [NSJSONSerialization JSONObjectWithData:self.receivedData options:NSJSONReadingMutableContainers error:&error];
+        }
+        else if (self.responseStatusCode == 200) {
+            NSMutableDictionary *result = [NSMutableDictionary dictionary];
+            [result setObject:self.responseObject.URL forKey:@"URL"];
+            [result setObject:@(self.responseStatusCode) forKey:@"statusCode"];
+            [result setObject:self.responseHeaders forKey:@"headers"];
+            [result setObject:@(NO) forKey:@"HasErrors"];
+            response = result;
+        }
+        if (self.delegate != nil && [self.delegate respondsToSelector:@selector(didReceiveResponse:forRequest:)]) {
+            
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [[BVAnalytics instance] queueAnalyticsEventForResponse:response forRequest:self.sender];
+            });
+            
+            [self.delegate didReceiveResponse:response forRequest:self.sender];
+        }
     }
 }
-
 
 @end


### PR DESCRIPTION
NSURLConnection is now deprecated in favor of NSURLSession.  This is an update that transitions the code base to use NSURLSession in the same capacity that NSURLConnection was used.

I ran all three demo projects with success and all tests in the testing project pass.