### PR TITLE
Add in parser for Form Fields in Conversations UGC submissions for Re…

### DIFF
--- a/Pod/BVCommon/BVNullHelper.h
+++ b/Pod/BVCommon/BVNullHelper.h
@@ -10,4 +10,13 @@
 
 #define SET_IF_NOT_NULL(target, value) if(value != [NSNull null]) { target = value; }
 
+static inline bool isObjectNilOrNull(NSObject *object){
+    
+    if (object == nil || object == [NSNull null]){
+        return true;
+    } else {
+        return false;
+    }
+}
+
 #endif /* BVNullHelper_h */

--- a/Pod/BVConversations/Display/Model/BVFormField.h
+++ b/Pod/BVConversations/Display/Model/BVFormField.h
@@ -1,0 +1,27 @@
+//
+//  BVFormField.h
+//  Conversations
+//
+//  Copyright © 2016 Bazaarvoice. All rights reserved.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "BVFormFieldOptions.h"
+
+@interface BVFormField : NSObject
+
+@property NSArray<BVFormFieldOptions *> * _Nonnull options;
+
+@property NSString * _Nonnull identifier;
+@property NSString * _Nonnull label;
+@property NSString * _Nonnull type;
+@property NSString * _Nonnull value;
+@property NSNumber * _Nonnull required; // Boolean
+@property NSNumber * _Nonnull minLength; // Integer
+@property NSNumber * _Nonnull maxLength; // Integer
+@property NSNumber * _Nonnull isDefault; // Boolean
+
+- (id _Nonnull)initWithFormFieldDictionary:(NSDictionary * _Nonnull)fieldDictionary;
+
+@end

--- a/Pod/BVConversations/Display/Model/BVFormField.m
+++ b/Pod/BVConversations/Display/Model/BVFormField.m
@@ -1,0 +1,65 @@
+//
+//  BVFormField.m
+//  Conversations
+//
+//  Copyright © 2016 Bazaarvoice. All rights reserved.
+//
+//
+
+#import "BVFormField.h"
+#import "BVNullHelper.h"
+#import "BVFormFieldOptions.h"
+
+@implementation BVFormField
+
+- (id)initWithFormFieldDictionary:(NSDictionary *)fieldDictionary{
+    
+    self = [super init];
+    
+    if (self){
+        
+        _identifier = @"";
+        _label = @"";
+        _type = @"";
+        _value = @"";
+        _required = [NSNumber numberWithBool:NO];
+        _isDefault = [NSNumber numberWithBool:NO];
+        _minLength = [NSNumber numberWithInteger:0];
+        _maxLength = [NSNumber numberWithInteger:0];
+        
+        SET_IF_NOT_NULL(_identifier, [fieldDictionary objectForKey:@"Id"]);
+        SET_IF_NOT_NULL(_label, [fieldDictionary objectForKey:@"Label"]);
+        SET_IF_NOT_NULL(_type, [fieldDictionary objectForKey:@"Type"]);
+        SET_IF_NOT_NULL(_value, [fieldDictionary objectForKey:@"Value"]);
+        
+        if (!isObjectNilOrNull([fieldDictionary objectForKey:@"MinLength"])){
+            _minLength = [NSNumber numberWithInteger:[[fieldDictionary objectForKey:@"MinLength"] integerValue]];
+        }
+        
+        if (!isObjectNilOrNull([fieldDictionary objectForKey:@"MaxLength"])){
+            _maxLength = [NSNumber numberWithInteger:[[fieldDictionary objectForKey:@"MaxLength"] integerValue]];
+        }
+        
+        if (!isObjectNilOrNull([fieldDictionary objectForKey:@"Required"])){
+            _required = [NSNumber numberWithInteger:[[fieldDictionary objectForKey:@"Required"] boolValue]];
+        }
+        
+        if (!isObjectNilOrNull([fieldDictionary objectForKey:@"Default"])){
+            _isDefault = [NSNumber numberWithInteger:[[fieldDictionary objectForKey:@"Default"] boolValue]];
+        }
+        
+        NSMutableArray *tmpOptions = [NSMutableArray array];
+        for (NSDictionary *optionsDict in [fieldDictionary objectForKey:@"Options"]){
+            BVFormFieldOptions *fieldOptions = [[BVFormFieldOptions alloc] initWithOptionsDictionary:optionsDict];
+            [tmpOptions addObject:fieldOptions];
+        }
+        
+        _options = [NSArray arrayWithArray:tmpOptions];
+        
+    }
+    return self;
+    
+}
+
+
+@end

--- a/Pod/BVConversations/Display/Model/BVFormFieldOptions.h
+++ b/Pod/BVConversations/Display/Model/BVFormFieldOptions.h
@@ -1,0 +1,19 @@
+//
+//  BVFormFieldOptions.h
+//  Pods
+//
+//  Copyright © 2016 Bazaarvoice. All rights reserved.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface BVFormFieldOptions : NSObject
+
+@property NSString* _Nonnull label;
+@property NSString* _Nonnull value;
+@property NSNumber* _Nonnull selected; // Boolean
+
+- (id _Nonnull)initWithOptionsDictionary:(NSDictionary * _Nonnull)dictionary;
+
+@end

--- a/Pod/BVConversations/Display/Model/BVFormFieldOptions.m
+++ b/Pod/BVConversations/Display/Model/BVFormFieldOptions.m
@@ -1,0 +1,39 @@
+//
+//  BVFormFieldOptions.m
+//  Pods
+//
+//  Copyright © 2016 Bazaarvoice. All rights reserved.
+//
+//
+
+#import "BVFormFieldOptions.h"
+#import "BVNullHelper.h"
+
+@implementation BVFormFieldOptions
+
+
+- (id)initWithOptionsDictionary:(NSDictionary *)dictionary{
+    
+    if (self){
+        
+        _label = @"";
+        _value = @"";
+        _selected = [NSNumber numberWithBool:NO];
+        
+        SET_IF_NOT_NULL(_label, [dictionary objectForKey:@"Label"])
+        SET_IF_NOT_NULL(_value, [dictionary objectForKey:@"Value"])
+        
+        if ([dictionary objectForKey:@"Selected"] != nil){
+            _selected = [NSNumber numberWithBool:[[dictionary objectForKey:@"Selected"] boolValue]];
+        }
+        
+    }
+    return self;
+    
+}
+
+
+
+
+
+@end

--- a/Pod/BVConversations/Submission/BVSubmissionResponse.h
+++ b/Pod/BVConversations/Submission/BVSubmissionResponse.h
@@ -17,6 +17,8 @@
 @property NSNumber* _Nullable typicalHoursToPost;
 @property NSString* _Nullable authorSubmissionToken;
 
+@property NSDictionary * _Nullable formFields;
+
 -(nonnull instancetype)initWithApiResponse:(nonnull NSDictionary*)apiResponse;
 
 @end

--- a/Pod/BVConversations/Submission/BVSubmissionResponse.m
+++ b/Pod/BVConversations/Submission/BVSubmissionResponse.m
@@ -7,6 +7,7 @@
 
 #import "BVSubmissionResponse.h"
 #import "BVNullHelper.h"
+#import "BVFormField.h"
 
 @implementation BVSubmissionResponse
 
@@ -18,6 +19,21 @@
         SET_IF_NOT_NULL(self.submissionId, apiResponse[@"SubmissionId"])
         SET_IF_NOT_NULL(self.typicalHoursToPost, apiResponse[@"TypicalHoursToPost"])
         SET_IF_NOT_NULL(self.authorSubmissionToken, apiResponse[@"AuthorSubmissionToken"])
+        
+        NSMutableDictionary *tmpFields = [NSMutableDictionary dictionary];
+        
+        NSDictionary *data = [apiResponse objectForKey:@"Data"];
+        if (data){
+            NSDictionary *fields = [data objectForKey:@"Fields"];
+            
+            for (NSDictionary *fieldDict in [fields allValues]){
+                BVFormField *formField = [[BVFormField alloc] initWithFormFieldDictionary:fieldDict];
+                [tmpFields setObject:formField forKey:formField.identifier];
+            }
+            
+            self.formFields = [NSDictionary dictionaryWithDictionary:tmpFields];
+            
+        }
         
     }
     return self;

--- a/Tests/Podfile.lock
+++ b/Tests/Podfile.lock
@@ -1,17 +1,17 @@
 PODS:
-  - BVSDK (4.2.1):
-    - BVSDK/Core (= 4.2.1)
-  - BVSDK/BVAdvertising (4.2.1):
+  - BVSDK (4.2.3):
+    - BVSDK/Core (= 4.2.3)
+  - BVSDK/BVAdvertising (4.2.3):
     - BVSDK/Core
-  - BVSDK/BVConversations (4.2.1):
+  - BVSDK/BVConversations (4.2.3):
     - BVSDK/Core
-  - BVSDK/BVCurations (4.2.1):
+  - BVSDK/BVCurations (4.2.3):
     - BVSDK/Core
-  - BVSDK/BVLocation (4.2.1):
+  - BVSDK/BVLocation (4.2.3):
     - BVSDK/Core
-  - BVSDK/BVRecommendations (4.2.1):
+  - BVSDK/BVRecommendations (4.2.3):
     - BVSDK/Core
-  - BVSDK/Core (4.2.1)
+  - BVSDK/Core (4.2.3)
   - OHHTTPStubs (5.1.0):
     - OHHTTPStubs/Default (= 5.1.0)
   - OHHTTPStubs/Core (5.1.0)
@@ -40,7 +40,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  BVSDK: fb8d0e2ed1646f3a1c14a09f8a00eb553ebc88fb
+  BVSDK: f08bad7bfd9270c1bdd2affc07835663f018de01
   OHHTTPStubs: 592f74439d2d72615115cf99a954237a3fbe26e5
 
 PODFILE CHECKSUM: 4a0dde118c062018ddcd485961583c2205de1274

--- a/Tests/Tests/ConversationsTests/SubmissionTests/AnswerSubmissionTests.swift
+++ b/Tests/Tests/ConversationsTests/SubmissionTests/AnswerSubmissionTests.swift
@@ -23,9 +23,10 @@ class AnswerSubmissionTests: XCTestCase {
     func testSubmitAnswerWithPhoto() {
         let expectation = expectationWithDescription("")
         
-        let answer = self.fillOutAnswer()
-        answer.submit({ (questionSubmission) in
+        let answer = self.fillOutAnswer(.Submit)
+        answer.submit({ (answerSubmission) in
             expectation.fulfill()
+             XCTAssertTrue(answerSubmission.formFields?.keys.count == 0)
         }, failure: { (errors) in
             expectation.fulfill()
             XCTFail()
@@ -34,7 +35,21 @@ class AnswerSubmissionTests: XCTestCase {
         waitForExpectationsWithTimeout(10, handler: nil)
     }
     
-    func fillOutAnswer() -> BVAnswerSubmission {
+    func testPreviewAnswerWithPhoto() {
+        let expectation = expectationWithDescription("")
+        let answer = self.fillOutAnswer(.Preview)
+        answer.submit({ (answerSubmission) in
+            expectation.fulfill()
+            XCTAssertTrue(answerSubmission.formFields?.keys.count == 22)
+        }, failure: { (errors) in
+            expectation.fulfill()
+            XCTFail()
+        })
+        
+        waitForExpectationsWithTimeout(10, handler: nil)
+    }
+    
+    func fillOutAnswer(action : BVSubmissionAction) -> BVAnswerSubmission {
         let answerText = "Answer text Answer text Answer text Answer text Answer text Answer text Answer text Answer text"
         let answer = BVAnswerSubmission(questionId: "6104", answerText: answerText)
         
@@ -47,7 +62,7 @@ class AnswerSubmissionTests: XCTestCase {
         answer.userId = "UserId" + randomId
         answer.userEmail = "developer@bazaarvoice.com"
         answer.agreedToTermsAndConditions = true
-        answer.action = .Submit
+        answer.action = action
         
         answer.addPhoto(PhotoUploadTests.createImage(), withPhotoCaption: "Yo dawg")
         

--- a/Tests/Tests/ConversationsTests/SubmissionTests/QuestionSubmissionTests.swift
+++ b/Tests/Tests/ConversationsTests/SubmissionTests/QuestionSubmissionTests.swift
@@ -22,9 +22,10 @@ class QuestionSubmissionTests: XCTestCase {
     func testSubmitQuestionWithPhoto() {
         let expectation = expectationWithDescription("")
         
-        let question = self.fillOutQuestion()
+        let question = self.fillOutQuestion(.Submit)
         question.submit({ (questionSubmission) in
             expectation.fulfill()
+            XCTAssertTrue(questionSubmission.formFields?.keys.count == 0)
         }, failure: { (errors) in
             XCTFail()
         })
@@ -32,7 +33,22 @@ class QuestionSubmissionTests: XCTestCase {
         waitForExpectationsWithTimeout(10, handler: nil)
     }
     
-    func fillOutQuestion() -> BVQuestionSubmission {
+    func testPreviewQuestionWithPhoto() {
+        let expectation = expectationWithDescription("")
+        
+        let question = self.fillOutQuestion(.Preview)
+        question.submit({ (questionSubmission) in
+            expectation.fulfill()
+            XCTAssertTrue(questionSubmission.formFields?.keys.count == 33)
+            }, failure: { (errors) in
+                XCTFail()
+        })
+        
+        waitForExpectationsWithTimeout(10, handler: nil)
+    }
+    
+    
+    func fillOutQuestion(action : BVSubmissionAction) -> BVQuestionSubmission {
         let question = BVQuestionSubmission(productId: "test1")
         let randomId = String(arc4random())
 
@@ -46,7 +62,7 @@ class QuestionSubmissionTests: XCTestCase {
         question.userId = "UserId" + randomId
         question.userEmail = "developer@bazaarvoice.com"
         question.agreedToTermsAndConditions = true
-        question.action = .Submit
+        question.action = action
         
         question.addPhoto(PhotoUploadTests.createImage(), withPhotoCaption: "Yo dawg")
         

--- a/Tests/Tests/ConversationsTests/SubmissionTests/ReviewSubmissionTests.swift
+++ b/Tests/Tests/ConversationsTests/SubmissionTests/ReviewSubmissionTests.swift
@@ -23,9 +23,10 @@ class ReviewSubmissionTests: XCTestCase {
         
         let expectation = expectationWithDescription("")
         
-        let review = self.fillOutReview()
+        let review = self.fillOutReview(.Submit)
         review.submit({ (reviewSubmission) in
             expectation.fulfill()
+            XCTAssertTrue(reviewSubmission.formFields?.keys.count == 0)
         }, failure: { (errors) in
             XCTFail()
             expectation.fulfill()
@@ -34,7 +35,24 @@ class ReviewSubmissionTests: XCTestCase {
         waitForExpectationsWithTimeout(10, handler: nil)
     }
     
-    func fillOutReview() -> BVReviewSubmission {
+    func testPreviewReviewWithPhoto() {
+        
+        let expectation = expectationWithDescription("")
+        
+        let review = self.fillOutReview(.Preview)
+        review.submit({ (reviewSubmission) in
+            expectation.fulfill()
+            XCTAssertTrue(reviewSubmission.formFields?.keys.count == 50)
+            }, failure: { (errors) in
+                XCTFail()
+                expectation.fulfill()
+        })
+        
+        waitForExpectationsWithTimeout(10, handler: nil)
+    }
+
+    
+    func fillOutReview(action : BVSubmissionAction) -> BVReviewSubmission {
         let review = BVReviewSubmission(reviewTitle: "review title",
                                       reviewText: "more than 50 more than 50 more than 50 more than 50 more than 50",
                                       rating: 4,
@@ -52,7 +70,7 @@ class ReviewSubmissionTests: XCTestCase {
         review.userId = "UserId" + randomId
         review.userEmail = "developer@bazaarvoice.com"
         review.agreedToTermsAndConditions = true
-        review.action = .Submit
+        review.action = action
         
         review.addContextDataValueBool("VerifiedPurchaser", value: false)
         review.addContextDataValueString("Age", value: "18to24")


### PR DESCRIPTION
…views/Questions/Answers. Response objects will contain an NSDictionary *formFields with all the form fields parsed. This dictionary will only be filled out in .Preview mode; it will be empty in .Submit mode.