### PR TITLE
Update dead link to Terms of Use

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Copyright (c) 2015 Bazaarvoice, Inc.
 
-https://developer.bazaarvoice.com/legal/terms_of_use for Bazaarvoice's Terms of Use.
+https://www.bazaarvoice.com/legal/terms-of-use/api/ for Bazaarvoice's Terms of Use.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,


### PR DESCRIPTION


## Description

Previous link to terms of use is not available:
https://developer.bazaarvoice.com/legal/terms_of_use

Please correct to API Terms of Use:
https://www.bazaarvoice.com/legal/terms-of-use/api/


